### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ endpoints.
 - http://localhost:8080/info/current-weather/sonsonate
 ![img.png](src/main/resources/static/img3.png)
 
-## Recomendacioens
+## Recomendaciones
 - Configurar las credenciales de acceso a la API de OpenWeatherMap.
 - Configurar la base de datos.
 - Añadir un usuario en la base de datos, este será el que permitirá realizar la autorización a las consultas.


### PR DESCRIPTION
## Summary
- correct typo in README header
- ensure the file ends with a newline

## Testing
- `sh mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685107a1ac1c832399d4814dde0dbf0d